### PR TITLE
some smoothing, and expand more aggressively again

### DIFF
--- a/bot.user.js
+++ b/bot.user.js
@@ -1319,7 +1319,7 @@ var bot = window.bot = (function (window) {
             }
             targetCourse = Math.min(
                 targetCourse,
-                (tailBehind - allowTail + 0.5 * (bot.snakeWidth - closePointDist)) /
+                (tailBehind - allowTail + (bot.snakeWidth - closePointDist)) /
                 bot.snakeWidth);
             // far away?
             targetCourse = Math.min(

--- a/bot.user.js
+++ b/bot.user.js
@@ -986,8 +986,8 @@ var bot = window.bot = (function (window) {
         // excludes points close to the head
         closestBodyPoint: function () {
             let head = {
-                x: window.snake.xx,
-                y: window.snake.yy
+                x: window.snake.xx + window.snake.fx,
+                y: window.snake.yy + window.snake.fy
             };
 
             let ptsLength = bot.pts.length;
@@ -1057,8 +1057,8 @@ var bot = window.bot = (function (window) {
         bodyDangerZone: function (
             offset, targetPoint, targetPointNormal, closePointDist, pastTargetPoint, closePoint) {
             var head = {
-                x: window.snake.xx,
-                y: window.snake.yy
+                x: window.snake.xx + window.snake.fx,
+                y: window.snake.yy + window.snake.fy
             };
             var pts = [
                 {
@@ -1119,8 +1119,8 @@ var bot = window.bot = (function (window) {
             }
 
             var head = {
-                x: window.snake.xx,
-                y: window.snake.yy
+                x: window.snake.xx + window.snake.fx,
+                y: window.snake.yy + window.snake.fy
             };
 
             let closePointT = bot.closestBodyPoint();

--- a/bot.user.js
+++ b/bot.user.js
@@ -994,16 +994,15 @@ var bot = window.bot = (function (window) {
 
             // skip head area
             let start_n = 0;
-            let start_d2 = canvas.getDistance2(head.x, head.y,
-                bot.pts[start_n].x, bot.pts[start_n].y);
+            let start_d2 = 0.0;
             while (start_n  < ptsLength) {
+                let prev_d2 = start_d2;
                 start_n ++;
-                let d2 = canvas.getDistance2(head.x, head.y,
+                start_d2 = canvas.getDistance2(head.x, head.y,
                     bot.pts[start_n].x, bot.pts[start_n].y);
-                if (d2 < start_d2) {
+                if (start_d2 < prev_d2) {
                     break;
                 }
-                start_d2 = d2;
             }
 
             if (start_n >= ptsLength || start_n <= 1) {
@@ -1026,6 +1025,8 @@ var bot = window.bot = (function (window) {
             let next_d2 = min_d2;
             if (min_n == ptsLength - 1) {
                 next_n = min_n - 1;
+                next_d2 = canvas.getDistance2(head.x, head.y,
+                    bot.pts[next_n].x, bot.pts[next_n].y);
             } else {
                 let d2m = canvas.getDistance2(head.x, head.y,
                     bot.pts[min_n - 1].x, bot.pts[min_n - 1].y);


### PR DESCRIPTION
Hi,

This is an experimental change. I tried to make bot's body continuous. That is, given by a continuous curve parametrized by length. This helps get rid of wiggling of bot's head. It was not a significant problem, but without this wiggle the bot looks more like a human player; and animation of visual debugging is a bit smoother.
